### PR TITLE
Fixed styles incompatibility between 4.12.3 and 4.13

### DIFF
--- a/css/templates/list/styles.css
+++ b/css/templates/list/styles.css
@@ -1,28 +1,6 @@
-/* The container for the list template output */
-div.wpra-list-template {
-	font-size: 100%;
-}
-
-/* An item in the list */
-div.wpra-list-template ul.wpra-item-list > li.wpra-item {
-	margin-bottom: 8px;
-}
-
-/* The item's title and link */
-div.wpra-list-template ul.wpra-item-list > li.wpra-item div.wpra-item-link {
-	display: inline-block;
-	vertical-align: text-top;
-	line-height: 1.4em;
-}
-
-/* The container for source, date and author */
-div.wpra-list-template ul.wpra-item-list > li.wpra-item > div.wprss-feed-meta {
-	line-height: 1.6em;
-}
-
 /* Separators between source, date and author */
 div.wpra-list-template ul.wpra-item-list > li.wpra-item > div.wprss-feed-meta > span {
-	font-size: 85%;
+	font-size: 90%;
 	clear: both;
 }
 div.wpra-list-template ul.wpra-item-list > li.wpra-item > div.wprss-feed-meta > span:not(:last-child):after {
@@ -47,6 +25,10 @@ ul.wpra-item-list--bullets.wpra-item-list--numbers {
  * Old styles
  */
 
+li.feed-item {
+	margin-bottom: 10px;
+}
+
 .thumbnail-excerpt {
 	overflow:hidden;
 	margin-bottom: 5px;
@@ -70,4 +52,3 @@ ul.wpra-item-list--bullets.wpra-item-list--numbers {
 	content: '';
 	clear: both;
 }
-

--- a/templates/feeds/list/feed-item.twig
+++ b/templates/feeds/list/feed-item.twig
@@ -5,10 +5,8 @@
 {% endif %}
 
 {# Show the title #}
-<div class="wpra-item-link">
-    {{ item_title | wpralink(item.permalink, options.title_is_link, options) }}
-    {{ options.title_after }}
-</div>
+{{ item_title | wpralink(item.permalink, options.title_is_link, options) }}
+{{ options.title_after }}
 
 {# Prepare date HTML class and formatted strinng #}
 {% set date_str = item.date|date(options.date_format) %}

--- a/templates/feeds/list/feed-list.twig
+++ b/templates/feeds/list/feed-list.twig
@@ -1,6 +1,6 @@
 {% set list_type = options.bullets_enabled and options.bullet_type == 'numbers' ? 'ol' : 'ul' %}
 
-<{{ list_type }} class="wpra-item-list {{ options.bullets_enabled ? 'wpra-item-list--bullets wpra-item-list--' ~ options.bullet_type : '' }}"
+<{{ list_type }} class="rss-aggregator wpra-item-list {{ options.bullets_enabled ? 'wpra-item-list--bullets wpra-item-list--' ~ options.bullet_type : '' }}"
     start="{{ (pagination.page - 1) *  pagination.items_per_page + 1}}">
     {% set hasItems = false %}
     {% for item in items %}


### PR DESCRIPTION
The fix of styles incompatibility between 4.12.3 and 4.13 consists of 2 simple points:

- do not introduce new styles,
- keep old structure and class names, so any user-created customization will work.
