### PR TITLE
Report installed plugin version in System Info

### DIFF
--- a/includes/system-info.php
+++ b/includes/system-info.php
@@ -29,6 +29,18 @@ function wprss_print_system_info() {
 
     $browser = new Browser();
 
+    // When the v4 engine runs inside a newer package (e.g. v5 in classic mode),
+    // WPRSS_VERSION is the engine's internal version, not the installed plugin
+    // version. Read the real version from the main plugin file so System Info
+    // doesn't read like the update failed.
+    $wprss_plugin_version = WPRSS_VERSION;
+    if ( defined( 'WPRSS_FILE_CONSTANT' ) && file_exists( WPRSS_FILE_CONSTANT ) ) {
+        $wprss_file_data = get_file_data( WPRSS_FILE_CONSTANT, array( 'Version' => 'Version' ) );
+        if ( ! empty( $wprss_file_data['Version'] ) ) {
+            $wprss_plugin_version = $wprss_file_data['Version'];
+        }
+    }
+
 ?>
 ### Begin System Info ###
 
@@ -39,7 +51,8 @@ Multi-site:               <?php echo is_multisite() ? 'Yes' . "\n" : 'No' . "\n"
 SITE_URL:                 <?php echo site_url() . "\n"; ?>
 HOME_URL:                 <?php echo home_url() . "\n"; ?>
 
-Plugin Version:           <?php echo WPRSS_VERSION . "\n"; ?>
+Plugin Version:           <?php echo $wprss_plugin_version . "\n"; ?>
+<?php if ( $wprss_plugin_version !== WPRSS_VERSION ) { echo 'Engine Version:           ' . WPRSS_VERSION . "\n"; } ?>
 WordPress Version:        <?php echo get_bloginfo( 'version' ) . "\n"; ?>
 
 <?php echo htmlspecialchars((string) $browser) ; ?>


### PR DESCRIPTION
This PR fixes System Info reporting the engine's internal version instead of the installed plugin version. Fixes #38.

In classic mode (a v4-origin site running inside a newer package), `includes/system-info.php` printed `WPRSS_VERSION` as the Plugin Version. That constant is the v4 engine's internal version (e.g. `4.23.13`) and is used across the engine for update checks and asset versioning, so it can't be bumped to match the package. The result was System Info showing an old number while the Plugins screen and Site Health correctly showed the installed version, which reads like a failed update and generates support tickets.

The change reads the real installed version from the main plugin file header (`WPRSS_FILE_CONSTANT`) via `get_file_data()` and prints that as Plugin Version. When the engine's internal version differs, it is shown on a separate `Engine Version` line so the engine in use is still visible for debugging. In a standalone v4 install the package and engine versions are identical, so the output is unchanged there.

Display-only change; no engine constants or update logic are touched.
